### PR TITLE
bootstrapを使って、グラフが２列に表示されるように変更。

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -38,7 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize', 
-    'plot'
+    'plot',
+    'django_bootstrap5', # 追加
 ]
 
 MIDDLEWARE = [

--- a/plot/graphs.py
+++ b/plot/graphs.py
@@ -1,15 +1,13 @@
 import plotly.graph_objects as go
 
 def line_charts(monthly_data):
-    # 月ごとの集計データを x (月) と y (値) に分解
     months = list(monthly_data.keys())
     values = list(monthly_data.values())
 
-    # 月ごとにソート
     sorted_months_values = sorted(zip(months, values))
     months, values = zip(*sorted_months_values)
 
-    print("months",months)
+    print("months", months)
     # Plotly グラフの作成
     fig = go.Figure(
         go.Scatter(x=months, y=values, mode='lines+markers', name='Monthly Data'),
@@ -17,16 +15,17 @@ def line_charts(monthly_data):
             title="Monthly Data Overview",
             xaxis_title="Month",
             yaxis_title="Count",
-            width=800, height=400,
+            autosize=True,
+            height=400,  # 高さを固定
             xaxis=dict(
                 tickmode='array',
                 tickvals=months,
-                ticktext=months,  # x軸のラベルとして月のみを表示
-                tickangle=-45    # 月ごとのラベルが重ならないように角度を調整
+                ticktext=months,
+                tickangle=-45
             )
         )
     )
-    return fig.to_html(include_plotlyjs=False)
+    return fig.to_html(full_html=False, include_plotlyjs='cdn')
 
 def bar_chart(monthly_data):
     months = list(monthly_data.keys())
@@ -42,7 +41,8 @@ def bar_chart(monthly_data):
         title="Monthly Data Overview",
         xaxis_title="Month",
         yaxis_title="Count",
-        width=800, height=400,
+        autosize=True,
+        height=400,  # 高さを固定
         xaxis=dict(
             tickmode='array',
             tickvals=months,
@@ -50,7 +50,7 @@ def bar_chart(monthly_data):
             tickangle=-45
         )
     )
-    return fig.to_html(include_plotlyjs=False)
+    return fig.to_html(full_html=False, include_plotlyjs='cdn')
 
 def user_bar_chart(user_data):
     users = list(user_data.keys())
@@ -66,7 +66,8 @@ def user_bar_chart(user_data):
         title="Data by User",
         xaxis_title="Users",
         yaxis_title="Count",
-        width=800, height=400,
+        autosize=True,
+        height=400,  # 高さを固定
         xaxis=dict(
             tickmode='array',
             tickvals=users,
@@ -74,4 +75,4 @@ def user_bar_chart(user_data):
             tickangle=-45
         )
     )
-    return fig.to_html(include_plotlyjs=False)
+    return fig.to_html(full_html=False, include_plotlyjs='cdn')

--- a/plot/templates/plot.html
+++ b/plot/templates/plot.html
@@ -1,38 +1,63 @@
+{% load django_bootstrap5 %}
+<head>
+    {% bootstrap_css %}
+    {% bootstrap_javascript %}
+</head>
 {% block head %}
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 {% endblock %}
 
 {% block content %}
-<div class="title"><h1>Plotlyのグラフを描画</h1></div>
+<div class="container-fluid">
+    <div class="title"><h1>Plotlyのグラフを描画</h1></div>
 
-<!-- Line Chart -->
-<div class="graph">
-    <h2>Line Chart</h2>
-    {{ line_chart|safe }}
+    <div class="row">
+        <!-- Line Chart -->
+        <div class="col-sm-12 col-lg-6 mb-4">
+            <div class="graph">
+                <h2>Line Chart</h2>
+                <div style="width:100%; overflow:hidden;">
+                    {{ line_chart|safe }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Bar Chart -->
+        <div class="col-sm-12 col-lg-6 mb-4">
+            <div class="graph">
+                <h2>Bar Chart</h2>
+                <div style="width:100%; overflow:hidden;">
+                    {{ bar_chart|safe }}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <!-- User Bar Chart -->
+        <div class="col-sm-12 col-lg-6 mb-4">
+            <div class="graph">
+                <h2>User Bar Chart</h2>
+                <div style="width:100%; overflow:hidden;">
+                    {{ user_bar_chart|safe }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Word Cloud -->
+        <div class="col-sm-12 col-lg-6 mb-4">
+            <div class="graph">
+                <h2>WordCloud</h2>
+                <img src="{{ wordcloud_image_url }}" alt="WordCloud Image" class="img-fluid">
+            </div>
+        </div>
+    </div>
+
+    <!-- Export Link -->
+    <div class="row">
+        <div class="col-12">
+            <a href="{% url 'plot:csv_export' %}" class="btn btn-primary">エクスポート</a>
+        </div>
+    </div>
 </div>
-
-<!-- Bar Chart -->
-<div class="graph">
-    <h2>Bar Chart</h2>
-    {{ bar_chart|safe }}
-</div>
-
-<!-- Bar Chart -->
-<div class="graph">
-    <h2>User Bar Chart</h2>
-    {{ user_bar_chart|safe }}
-</div>
-
-<!-- Word Cloud -->
-<div class="graph">
-    <h2>WordCloud</h2>
-    <img src="{{ wordcloud_image_url }}" alt="WordCloud Image" style="width:800px;height:600px;">
-</div>
-
-<!-- Export Link -->
-
-<div>
-    <a href="{% url 'plot:csv_export' %}" class="">エクスポート</a>
-</div>
-
 {% endblock %}


### PR DESCRIPTION
bootstrapを使って、グラフが２列に表示されるように変更。レスポンシブにグラフ幅が変更され、かつwindow幅がsm(576px)サイズ以下ではグラフが１列になるように表示。
<img width="810" alt="image" src="https://github.com/user-attachments/assets/e60e3d4a-88f8-4df9-a865-62bec0335c97">
